### PR TITLE
Make JavaScriptUserConfig compatible with new Django 1.10-style middleware and old style.

### DIFF
--- a/javascript_settings/context_processors.py
+++ b/javascript_settings/context_processors.py
@@ -1,6 +1,6 @@
+import json
 from configuration_builder import DEFAULT_CONFIGURATION_BUILDER
 
-from django.utils import simplejson
 
 def get_config(request):
-    return { 'javascript_settings': simplejson.dumps(DEFAULT_CONFIGURATION_BUILDER.get_configuration(request)) }
+    return { 'javascript_settings': json.dumps(DEFAULT_CONFIGURATION_BUILDER.get_configuration(request)) }

--- a/javascript_settings/middleware.py
+++ b/javascript_settings/middleware.py
@@ -1,4 +1,7 @@
-class JavaScriptUserConfig(object):
+from django.utils.deprecation import MiddlewareMixin
+
+
+class JavaScriptUserConfig(MiddlewareMixin):
     """ 
         Adds abbility to add parameters to javascript_settings
         from view.

--- a/javascript_settings/templatetags/javascript_settings_tags.py
+++ b/javascript_settings/templatetags/javascript_settings_tags.py
@@ -1,5 +1,5 @@
+import json
 from django import template
-from django.utils import simplejson
 
 
 from javascript_settings.configuration_builder import DEFAULT_CONFIGURATION_BUILDER
@@ -39,7 +39,7 @@ class JavascriptConfigurationNode(template.Node):
 	if 'request' not in context:
             return ''
 
-        return js_code % simplejson.dumps(
+        return js_code % json.dumps(
                 DEFAULT_CONFIGURATION_BUILDER.get_configuration(context['request'])
                 )
 

--- a/javascript_settings/views.py
+++ b/javascript_settings/views.py
@@ -1,10 +1,10 @@
+import json
 from django.http import HttpResponse
-from django.utils import simplejson
 
 from configuration_builder import DEFAULT_CONFIGURATION_BUILDER
 
 def load_configuration(request):
-    return HttpResponse("var configuration = %s;" % simplejson.dumps(
+    return HttpResponse("var configuration = %s;" % json.dumps(
         DEFAULT_CONFIGURATION_BUILDER.get_configuration(request)
     ))
 


### PR DESCRIPTION
[Upgrading pre-Django 1.10-style middleware](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)